### PR TITLE
Patch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ jobs:
       - name: Typst
         uses: lvignoli/typst-action@main
         with:
-            options: |
-              --font-path
-              fonts
+          options: |
+            --font-path
+            fonts
           source_file: |
             first_file.typ
             second_file.typ

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ jobs:
       - name: Typst
         uses: lvignoli/typst-action@main
         with:
+            options: |
+              --font-path
+              fonts
           source_file: |
             first_file.typ
             second_file.typ

--- a/README.md
+++ b/README.md
@@ -78,3 +78,17 @@ Repository [lvignoli/typst-action-example](https://github.com/lvignoli/typst-act
 - I was hasty to tag for a v1. I have now deleted it.
   As long as Typst is not in a stable state, the action will stay in v0.
   You should use `lvignoli/typst-action@main` in the meantime.
+
+## Extra
+
+To specify the output filename use `:` in the filename to denote the name, such as:
+```
+      - name: Typst
+        uses: lvignoli/typst-action@main
+        with:
+          source_file: |
+            first_file.typ:first.pdf
+            second_file.typ
+            third_and_final_file.typ:third.pdf
+
+```

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -4,14 +4,14 @@ import subprocess
 import sys
 
 
-def compile(filename: str, options: list[str], outputname: str | None) -> bool:
+def compile(filename: str, options: list[str], outputfilename: str | None) -> bool:
     """Compiles a Typst file with the specified global options.
 
     Returns True if the typst command exited with status 0, False otherwise.
     """
     command = ["typst"] + options + ["compile", filename]
-    if outputname is not None:
-        command.append(outputname)
+    if outputfilename is not None:
+        command.append(outputfilename)
     logging.debug("Running: " + " ".join(command))
 
     result = subprocess.run(command, capture_output=True, text=True)
@@ -53,7 +53,7 @@ def main():
         if outputfilename == "":
             outputfilename = None
         elif outputfilename is not None:
-            outputfilename = outputfilename.strip
+            outputfilename = outputfilename.strip()
         logging.info(f"Compiling {filename}…")
         success[filename] = compile(filename, options, outputfilename)
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 
-def compile(filename: str, options: list[str], outputname: string | None) -> bool:
+def compile(filename: str, options: list[str], outputname: str | None) -> bool:
     """Compiles a Typst file with the specified global options.
 
     Returns True if the typst command exited with status 0, False otherwise.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -12,7 +12,7 @@ def compile(filename: str, options: list[str], outputfilename: str | None) -> bo
     command = ["typst", "compile"] + options + [filename]
     if outputfilename is not None:
         command.append(outputfilename)
-    logging.debug("Running: " + " ".join(command))
+    logging.info("Running: " + " ".join(command))
 
     result = subprocess.run(command, capture_output=True, text=True)
     try:

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -9,7 +9,7 @@ def compile(filename: str, options: list[str], outputfilename: str | None) -> bo
 
     Returns True if the typst command exited with status 0, False otherwise.
     """
-    command = ["typst"] + options + ["compile", filename]
+    command = ["typst", "compile"] + options + [filename]
     if outputfilename is not None:
         command.append(outputfilename)
     logging.debug("Running: " + " ".join(command))


### PR DESCRIPTION
I've added the ability to add an "output" file version, because the code accepts multiple input files, I had to improvise with using a `:` to separate the values. 

Tested only on my use case sorry.

The options were also in the wrong spot and running the 'root' options as they seem to be positional. It seems some options such as font are quietly accepted despite being in the wrong location