### PR TITLE
update upload-artifact dependency

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
           test -e "tests/valid.pdf"
           test -e "tests/math.pdf"
       - name: upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Output PDF files
           path: tests/*.pdf

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
             third_and_final_file.typ
 
       - name: Upload PDF file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: PDF
           path: *.pdf


### PR DESCRIPTION
From https://github.com/actions/upload-artifact?tab=readme-ov-file ,
actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. We can just change v3 to v4 as we do not use complex features that have break changes in this update.