### PR TITLE
Fix typst argument

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -9,7 +9,7 @@ def compile(filename: str, options: list[str]) -> bool:
 
     Returns True if the typst command exited with status 0, False otherwise.
     """
-    command = ["typst"] + options + ["compile", filename]
+    command = ["typst", "compile"] + options + [filename]
     logging.debug("Running: " + " ".join(command))
 
     result = subprocess.run(command, capture_output=True, text=True)


### PR DESCRIPTION
"compile" command should be the first argument. This allows using options (such as for adding fonts) again.